### PR TITLE
Spring Helper Bones Introduced

### DIFF
--- a/helper_rig.py
+++ b/helper_rig.py
@@ -118,9 +118,7 @@ class HelperBonesHandler:
             
             simulated_locations[helper_end_idx] = free_mass_locations[i]
             self.prev_bone_locations = simulated_locations
-            
-            print(free_mass_locations[i] - rigidly_posed_locations[helper_end_idx])
-        
+                    
         if exclude_root:
             return simulated_locations[2:]
         return simulated_locations

--- a/helper_rig.py
+++ b/helper_rig.py
@@ -9,7 +9,7 @@ Created on Sat Oct 12 10:05:05 2024
 from skeleton import Skeleton, Bone
 from mass_spring import MassSpringSystem
 
-class SpringRigContainer:
+class HelperBonesHandler:
     
     def __init__(self, helper_bones, mass=1.0, stiffness=100):
         """

--- a/helper_rig.py
+++ b/helper_rig.py
@@ -11,7 +11,8 @@ from mass_spring import MassSpringSystem
 
 class HelperBonesHandler:
     
-    def __init__(self, skeleton, helper_indices, mass=1.0, stiffness=100):
+    def __init__(self, skeleton, helper_indices, mass=1.0, stiffness=100,
+                 mass_dscale=1.0, spring_dscale=0.01):
         """
         Create a mass-spring system provided an array of Bone objects.
         Every bone is modelled as two masses at the tip points, connected
@@ -40,10 +41,10 @@ class HelperBonesHandler:
             helper_start = helper_bones[i].start_location
             helper_end = helper_bones[i].end_location
             
-            mass1 = self.ms_system.add_mass(helper_start, mass=mass)
-            mass2 = self.ms_system.add_mass(helper_end, mass=mass)
+            mass1 = self.ms_system.add_mass(helper_start, mass=mass, dscale=mass_dscale)
+            mass2 = self.ms_system.add_mass(helper_end, mass=mass, dscale=mass_dscale)
             
-            self.ms_system.connect_masses(mass1, mass2, stiffness=stiffness)
+            self.ms_system.connect_masses(mass1, mass2, stiffness=stiffness, dscale=spring_dscale)
             self.ms_system.fix_mass(mass1)
     
         self.fixed_idx = self.ms_system.fixed_indices

--- a/helper_rig.py
+++ b/helper_rig.py
@@ -5,42 +5,36 @@ Created on Sat Oct 12 10:05:05 2024
 
 @author: bartu
 """
-
+import numpy as np
 from skeleton import Skeleton, Bone
 from mass_spring import MassSpringSystem
 
 class HelperBonesHandler:
     
-    def __init__(self, helper_bones, mass=1.0, stiffness=100):
+    def __init__(self, skeleton, helper_indices, mass=1.0, stiffness=100):
         """
         Create a mass-spring system provided an array of Bone objects.
         Every bone is modelled as two masses at the tip points, connected
         via a spring. The beginning mass of the bone is fixed, so that only the
         ending mass is jiggling.
 
-        Parameters
-        ----------
-        helper_bones : List or Array
-            A list of Bone objects that will be converted to single mass-spring
-            simulations.
-        mass : TYPE, optional
-            DESCRIPTION. The default is 1.0.
-
-        Returns
-        -------
-        None.
-
         """
+        self.skeleton = skeleton
+        helper_bones = np.array(skeleton.rest_bones)[helper_indices]
+ 
         self.dt = 1. / 24
         self.ms_system = MassSpringSystem(self.dt)
     
         n_helper = len(helper_bones)
         for i in range(n_helper):
-            m1_idx = self.ms_system.add_mass(mass_coordinate=helper_bones[i].start_location, mass=mass)
-            m2_idx = self.ms_system.add_mass(mass_coordinate=helper_bones[i].end_location, mass=mass)
+            helper_start = helper_bones[i].start_location
+            helper_end = helper_bones[i].end_location
             
-            self.ms_system.connect_masses(int(m1_idx), int(m2_idx), stiffness=stiffness)
-            self.ms_system.fix_mass(m1_idx)
+            mass1 = self.ms_system.add_mass(helper_start, mass=mass)
+            mass2 = self.ms_system.add_mass(helper_end, mass=mass)
+            
+            self.ms_system.connect_masses(mass1, mass2, stiffness=stiffness)
+            self.ms_system.fix_mass(mass1)
     
         self.fixed_idx = self.ms_system.fixed_indices
         self.free_idx = self.ms_system.get_free_mass_indices()
@@ -48,6 +42,12 @@ class HelperBonesHandler:
     # for optimization we should be able to provide an array of particle mass
     # that will update the individual Particle.mass in the system
     
+    def update(self, current_skeleton):
+        
+        simulated_locations = None
+        
+        return simulated_locations
+        
     
     
     

--- a/helper_rig.py
+++ b/helper_rig.py
@@ -20,11 +20,21 @@ class HelperBonesHandler:
 
         """
         self.skeleton = skeleton
+        self.prev_bone_locations = skeleton.get_rest_bone_locations(exclude_root=False) 
+        print("WARNING: The prev_bone_locations are set at rest locations initially. \
+              However it should be set before the beginning of the animation because rest position might not be animated at all.")
+        # TODO: If what you're returning is actually the JOINT locations, why are you
+        # calling these variables and functions as BONE locations? What is a location of
+        # a bone afterall?
+        
+        self.helper_indices = helper_indices
         helper_bones = np.array(skeleton.rest_bones)[helper_indices]
  
         self.dt = 1. / 24
         self.ms_system = MassSpringSystem(self.dt)
     
+        print("WARNING: Masses should be initiated NOT at the rest pose but the first keyframe pose \
+              to be simulated in between the frames")
         n_helper = len(helper_bones)
         for i in range(n_helper):
             helper_start = helper_bones[i].start_location
@@ -42,10 +52,68 @@ class HelperBonesHandler:
     # for optimization we should be able to provide an array of particle mass
     # that will update the individual Particle.mass in the system
     
-    def update(self, current_skeleton):
+    def update(self, theta, trans, degrees, exclude_root):
+        """
+        Given the relative rotations, update the skeleton joints with mass-spring
+        system and return the resulting joint locations.
+
+        Parameters
+        ----------
+        theta : np.ndarray
+            DESCRIPTION.
+        degrees : bool 
+            DESCRIPTION.
+        exclude_root : bool
+            DESCRIPTION.
+
+        Returns
+        -------
+        simulated_locations : np.ndarray
+            Coordinates of the simulated bones. It has shape of (2*n_bones, 3)
+            if exclude_root is set to False. If exclude_root is True, the returned
+            array has shape (2*(n_bones-1), 3) where every consecutive points 
+            are defining two endpoints of a bone, where bone is a line segment.
+        """
+        if type(theta) is list:
+            theta = np.array(theta)
+        elif type(theta) is not np.ndarray:
+            print(f"WARNING: Theta is expected to be either list or np.ndarray type, got {type(theta)}.")
+        assert type(degrees) == bool, f"Expected degrees parameter to have type bool, got {type(degrees)}"
+        assert type(exclude_root) == bool, f"Expected exclude_root parameter to have type bool, got {type(exclude_root)}"
+
+        # TODO: exclude_root=False is intentional! Do not delete it! But also it's not
+        # a good design if you're not using the same parameter name, your intention is unclear
+        # so maybe you could remove this exclude_root option all together and handle it elsewhere
+        posed_bone_locations = self.skeleton.pose_bones(theta, trans, degrees=degrees, exclude_root=False)
         
-        simulated_locations = None
+        simulated_locations = posed_bone_locations
+        for i, helper_idx in enumerate(self.helper_indices):
+            
+            # TODO: why don't you rename ms_system that doesn't sound like a meaningful name?
+            # even system could be more meaningful though it might be close to a keyword
+            # maybe self.simulator could work.
+            mass_idx = self.fixed_idx[i]
+            diff = posed_bone_locations - self.prev_bone_locations
+            helper_end_idx = (2 * helper_idx) + 1 # since bone locations have 2 joints per bone, multiply helper_bone_idx by 2 
+            translate_vec = diff[helper_end_idx]  # TODO: then why don't you have a better data structure? Maybe dict could 
+                                                  # work to access diff[helper_idx]["end"] or diff[helper_idx].end_location to
+                                                  # access the bone.
+            
+            # Step 1 - Translate the endpoint of the current helper bone
+            # TODO: are you handling the chained helper bones? like the start of
+            # the children bone should be relocated in that case, 
+            # and FK needed to be  re-called?
+            self.ms_system.translate_mass(mass_idx, translate_vec)
+            self.ms_system.simulate()
+
+            # Step 2 - Get current mass positions
+            cur_mass_locations = self.ms_system.get_mass_locations()
+            free_mass_locations = cur_mass_locations[self.free_idx]
+            
+            simulated_locations[helper_end_idx] = free_mass_locations[i]
         
+        if exclude_root:
+            return simulated_locations[2:]
         return simulated_locations
         
     

--- a/mass_spring.py
+++ b/mass_spring.py
@@ -16,14 +16,13 @@ import numpy as np
 import pyvista as pv
 
 from sanity_check import _is_equal
-from global_vars import _SPACE_DIMS_
+from global_vars import _SPACE_DIMS_, VERBOSE
 
 _DEFAULT_STIFFNESS = 0.5
 _DEFAULT_DAMPING = 1.0
 _DEFAULT_MASS = 2.5
 _DEFAULT_SPRING_SCALE = 1
 _DEFAULT_MASS_SCALE = 1 # Default is 0.1 but the simulation doesn't work at 0.1...
-_VERBOSE = False
 class Particle:
     def __init__(self, 
                  coordinate, 
@@ -74,7 +73,7 @@ class Spring:
                  stiffness : float, 
                  damping : float,
                  dscale : float = _DEFAULT_SPRING_SCALE,
-                 verbose : bool = _VERBOSE
+                 verbose : bool = VERBOSE
                  ):
         
         # TODO: Are you going to implement squared norms for optimized performance?
@@ -90,7 +89,7 @@ class Spring:
         self.m1 = beginning_mass
         self.m2 = ending_mass
         
-    def get_force_on_mass(self, mass : Particle, verbose=_VERBOSE):
+    def get_force_on_mass(self, mass : Particle, verbose=VERBOSE):
         
         distance = np.linalg.norm(self.m1.center - self.m2.center)
         if distance < 1e-16:
@@ -146,12 +145,13 @@ class MassSpringSystem:
             self.masses[i].center += velocity * dt * self.masses[i].dscale
             self.masses[i].velocity = (self.masses[i].center - previous_position) / dt
             
-    def add_mass(self, mass_coordinate, mass=_DEFAULT_MASS,  gravity=False, verbose=_VERBOSE):
+    def add_mass(self, mass_coordinate, mass=_DEFAULT_MASS,  gravity=False, verbose=VERBOSE):
         mass = Particle(mass_coordinate, mass=mass, gravity=gravity)
         
         if type(mass) is Particle:
             if verbose: print(f">> Added mass at {mass.center}")
             self.masses.append(mass)
+            return len(self.masses) - 1  # Return the index of the appended mass
         else:
             print(f"Expected Particle class, got {type(mass)}")
             

--- a/mass_spring.py
+++ b/mass_spring.py
@@ -165,7 +165,7 @@ class MassSpringSystem:
     def get_free_mass_indices(self):
         indices = np.arange(0, len(self.masses))
         free_mass_indices = np.delete(indices, self.fixed_indices)
-        return free_mass_indices
+        return np.array(free_mass_indices)
         
     def remove_mass(self, mass_idx):
         # TODO: remove mass dictionary entry

--- a/mass_spring.py
+++ b/mass_spring.py
@@ -108,13 +108,16 @@ class Spring:
         s2 = np.dot(self.m2.velocity, normalized_dir)
         damping_force_amount = -self.kd * (s1 + s2)
         
+        force = None
         if self.m1 == mass:
-            return (spring_force_amount + damping_force_amount) * normalized_dir
+            force = (spring_force_amount + damping_force_amount) * normalized_dir
         elif self.m2 == mass:
-            return (-spring_force_amount + damping_force_amount) * normalized_dir
+            force = (-spring_force_amount + damping_force_amount) * normalized_dir
         else:
             print(">> WARNING: Unexpected case occured, given mass location does not exist for this spring. No force is exerted.")
-            return None 
+          
+        assert not np.any(force > 1e10), f"WARNING: System got unstable with force {force}, stopping execution..."
+        return force
         
         
 class MassSpringSystem:

--- a/mass_spring.py
+++ b/mass_spring.py
@@ -121,6 +121,7 @@ class MassSpringSystem:
     def __init__(self, dt):
         print(">> Initiated empty mass-spring system")
         self.masses = []
+        self.fixed_indices = []
         self.connections = []
         self.dt =  dt
         
@@ -155,8 +156,9 @@ class MassSpringSystem:
         else:
             print(f"Expected Particle class, got {type(mass)}")
             
-    def fix_mass(self, mass_idx, verbose=False):
+    def fix_mass(self, mass_idx, verbose=VERBOSE):
         self.masses[mass_idx].mass = 0.0
+        self.fixed_indices.append(mass_idx)
         if verbose: print(f">> Fixed mass at location {self.masses[mass_idx].center}")
         return
         

--- a/mass_spring.py
+++ b/mass_spring.py
@@ -161,6 +161,11 @@ class MassSpringSystem:
         self.fixed_indices.append(mass_idx)
         if verbose: print(f">> Fixed mass at location {self.masses[mass_idx].center}")
         return
+    
+    def get_free_mass_indices(self):
+        indices = np.arange(0, len(self.masses))
+        free_mass_indices = np.delete(indices, self.fixed_indices)
+        return free_mass_indices
         
     def remove_mass(self, mass_idx):
         # TODO: remove mass dictionary entry

--- a/mass_spring.py
+++ b/mass_spring.py
@@ -149,8 +149,9 @@ class MassSpringSystem:
             self.masses[i].center += velocity * dt * self.masses[i].dscale
             self.masses[i].velocity = (self.masses[i].center - previous_position) / dt
             
-    def add_mass(self, mass_coordinate, mass=_DEFAULT_MASS,  gravity=False, verbose=VERBOSE):
-        mass = Particle(mass_coordinate, mass=mass, gravity=gravity)
+    def add_mass(self, mass_coordinate, mass=_DEFAULT_MASS, dscale=_DEFAULT_MASS_SCALE,
+                 gravity=False, verbose=VERBOSE):
+        mass = Particle(mass_coordinate, mass=mass, dscale=dscale, gravity=gravity)
         
         if type(mass) is Particle:
             if verbose: print(f">> Added mass at {mass.center}")

--- a/skeleton.py
+++ b/skeleton.py
@@ -302,8 +302,8 @@ class Skeleton():
 
         Returns
         -------
-        None.
-
+        new_bone.idx : int
+        Returns the index of the inserted bone in the Skeleton.bones list.
         """
         if not type(parent_idx) == int:
             assert np.issubdtype(parent_idx, np.integer), f"Expected parent index to be an integer, got {type(parent_idx)}"
@@ -326,7 +326,10 @@ class Skeleton():
                 self.bones[new_bone.idx].translate(parent_dir_scaled, override=True)
         else:
             self.bones[new_bone.idx].start_location = startpoint
-            
+        
+        # Sanity check the created bone.idx corresponds to its index the bones list
+        assert new_bone.idx == len(self.bones)-1
+        return new_bone.idx
     
     def remove_bone(self, bone_idx):
         bone_to_be_removed = self.bones[bone_idx]
@@ -379,6 +382,7 @@ class Skeleton():
             
         return bone_endpoints
     
+
 if __name__ == "__main__":
     print(">> Testing skeleton.py...")
     

--- a/skeleton.py
+++ b/skeleton.py
@@ -352,7 +352,7 @@ class Skeleton():
         assert bone_idx < len(self.rest_bones), f">> Invalid bone index {bone_idx}. Please select an index less than {len(self.rest_bones)}"
         return self.rest_bones[bone_idx]
     
-    def get_rest_bone_locations(self, exclude_root=True):
+    def get_rest_bone_locations(self, exclude_root):
         """
         Get the bone joint locations for the entire skeleton. Note that this is
         not the same as SMPL joint locations. In this skeleton, every bone has

--- a/spring_rig_helper.py
+++ b/spring_rig_helper.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Created on Sat Oct 12 10:05:05 2024
+
+@author: bartu
+"""
+
+from skeleton import Skeleton, Bone
+from mass_spring import MassSpringSystem
+
+class SpringRigContainer:
+    
+    def __init__(self, helper_bones, mass=1.0, stiffness=100):
+        """
+        Create a mass-spring system provided an array of Bone objects.
+        Every bone is modelled as two masses at the tip points, connected
+        via a spring. The beginning mass of the bone is fixed, so that only the
+        ending mass is jiggling.
+
+        Parameters
+        ----------
+        helper_bones : List or Array
+            A list of Bone objects that will be converted to single mass-spring
+            simulations.
+        mass : TYPE, optional
+            DESCRIPTION. The default is 1.0.
+
+        Returns
+        -------
+        None.
+
+        """
+        self.dt = 1. / 24
+        self.ms_system = MassSpringSystem(self.dt)
+    
+        n_helper = len(helper_bones)
+        for i in range(n_helper):
+            m1_idx = self.ms_system.add_mass(mass_coordinate=helper_bones[i].start_location, mass=mass)
+            m2_idx = self.ms_system.add_mass(mass_coordinate=helper_bones[i].end_location, mass=mass)
+            
+            self.ms_system.connect_masses(int(m1_idx), int(m2_idx), stiffness=stiffness)
+            self.ms_system.fix_mass(m1_idx)
+    
+    # TODO: We should be able to change the individual masses and stiffness, 
+    # for optimization we should be able to provide an array of particle mass
+    # that will update the individual Particle.mass in the system
+    
+    
+    
+    

--- a/spring_rig_helper.py
+++ b/spring_rig_helper.py
@@ -42,6 +42,8 @@ class SpringRigContainer:
             self.ms_system.connect_masses(int(m1_idx), int(m2_idx), stiffness=stiffness)
             self.ms_system.fix_mass(m1_idx)
     
+        self.fixed_idx = self.ms_system.fixed_indices
+        self.free_idx = self.ms_system.get_free_mass_indices()
     # TODO: We should be able to change the individual masses and stiffness, 
     # for optimization we should be able to provide an array of particle mass
     # that will update the individual Particle.mass in the system

--- a/tests/fk_test_spring.py
+++ b/tests/fk_test_spring.py
@@ -13,7 +13,7 @@ import pyvista as pv
 
 import __init__
 from skeleton import Skeleton
-from spring_rig_helper import SpringRigContainer
+from helper_rig import HelperBonesHandler
 from pyvista_render_tools import add_skeleton
 from global_vars import IGL_DATA_PATH, RESULT_PATH
 
@@ -82,7 +82,7 @@ helper_indices  = add_helper_bones(test_skeleton, helper_bone_endpoints,
                                      startpoints=helper_bone_endpoints-1e-6)
 
 helper_bones = np.array(test_skeleton.bones)[helper_indices]
-helper_rig = SpringRigContainer(helper_bones) # TODO: could you do the naming more consistent? i.e. spring_rig_helper SpringRigContainer and helper_rig are all different names!
+helper_rig = HelperBonesHandler(helper_bones) # TODO: could you do the naming more consistent? i.e. spring_rig_helper SpringRigContainer and helper_rig are all different names!
 
 
 # TODO: you could also add insert_point_handle() to Skeleton class
@@ -110,7 +110,7 @@ line_segments = np.reshape(np.arange(0, 2*(n_bones-1)), (n_bones-1, 2))
 skel_mesh = add_skeleton(plotter, rest_bone_locations, line_segments)
 plotter.open_movie(RESULT_PATH + "/igl-skeleton.mp4")
 
-n_repeats = 20
+n_repeats = 10
 n_frames = 2
 for _ in range(n_repeats):
     for frame in range(n_frames):

--- a/tests/fk_test_spring.py
+++ b/tests/fk_test_spring.py
@@ -28,13 +28,16 @@ def create_skeleton(joint_locations, kintree):
     return test_skeleton
 
 def add_helper_bones(test_skeleton, helper_bone_endpoints, helper_bone_parents,
-                     offset_ratio):
+                     offset_ratio=0.0, startpoints=[]):
     n_helper = len(helper_bone_parents)
+    if len(startpoints)==0: startpoints = np.repeat([None],n_helper)
+    
     for i in range(n_helper):
         test_skeleton.insert_bone(endpoint = helper_bone_endpoints[i],
                                   parent_idx = helper_bone_parents[i],
                                   at_the_tip=False,
                                   offset_ratio = offset_ratio,
+                                  startpoint = startpoints[i]
                                   )
 # ---------------------------------------------------------------------------- 
 # Set skeletal animation data
@@ -57,7 +60,7 @@ pose = np.array([
                 [
                  [0.,0.,0.],
                  [0.,0.,0.],
-                 [0., 20., 0.],
+                 [10., 10., 0.],
                  [0.,0.,0.],
                  [0.,0.,0.],
                  [0.,0.,0.],
@@ -69,7 +72,9 @@ pose = np.array([
 # ---------------------------------------------------------------------------- 
 
 test_skeleton = create_skeleton(joint_locations, kintree)
-add_helper_bones(test_skeleton, helper_bone_endpoints, helper_bone_parents, offset_ratio=0.5)
+add_helper_bones(test_skeleton, helper_bone_endpoints, 
+                 helper_bone_parents, #offset_ratio=0.0,
+                 startpoints=helper_bone_endpoints-1e-4)
 
 # ---------------------------------------------------------------------------- 
 # Create plotter 
@@ -97,7 +102,7 @@ n_repeats = 20
 n_frames = 2
 for _ in range(n_repeats):
     for frame in range(n_frames):
-        for _ in range(24 * 3):
+        for _ in range(24 * 2):
             theta = pose[frame]
             #t = trans[frame]
             posed_bone_locations = test_skeleton.pose_bones(theta, degrees=True, exclude_root=EXCLUDE_ROOT)

--- a/tests/fk_test_spring.py
+++ b/tests/fk_test_spring.py
@@ -74,6 +74,9 @@ pose = np.array([
                 ]
                 ])
 
+DEGREES = True # Set true if pose is represented with degrees as Euler angles.
+MODE = "Dynamic"
+
 # ---------------------------------------------------------------------------- 
 # Create rig and set helper bones
 # ---------------------------------------------------------------------------- 
@@ -116,16 +119,15 @@ for _ in range(n_repeats):
     for frame in range(n_frames):
         for _ in range(24 * 2):
             theta = pose[frame]
-            #t = trans[frame]
-            posed_bone_locations = test_skeleton.pose_bones(theta, degrees=True, exclude_root=EXCLUDE_ROOT)
+            trans = None
+            # WARNING (TODO): No relative translation yet!
             
-            # TODO: simulate the mass
-            simulated_locations = helper_rig.update(test_skeleton)
-            print(">>> Simulated locations", simulated_locations)
-            
-            # TODO: update the posed_bone_locations (maybe not directly update the skeleton bones' locations?)
-            print(">> WARNING: PLEASE DON'T FORGET TO UPDATE THE BONE TIPS... See the line below")
-            skel_mesh.points = posed_bone_locations
+            if MODE == "Rigid":
+                rigid_bone_locations = test_skeleton.pose_bones(theta, trans, degrees=DEGREES, exclude_root=EXCLUDE_ROOT)
+                skel_mesh.points = rigid_bone_locations
+            else:
+                simulated_bone_locations = helper_rig.update(theta, trans, degrees=DEGREES, exclude_root=EXCLUDE_ROOT)
+                skel_mesh.points = simulated_bone_locations
     
             # Write a frame. This triggers a render.
             plotter.write_frame()

--- a/tests/fk_test_spring.py
+++ b/tests/fk_test_spring.py
@@ -76,7 +76,10 @@ pose = np.array([
 
 DEGREES = True # Set true if pose is represented with degrees as Euler angles.
 MODE = "Dynamic"
-
+MASS = 10.0
+STIFFNESS = 100.0
+MASS_DSCALE = 0.1
+SPRING_DSCALE = 0.01
 # ---------------------------------------------------------------------------- 
 # Create rig and set helper bones
 # ---------------------------------------------------------------------------- 
@@ -86,7 +89,12 @@ helper_indices = add_helper_bones(test_skeleton, helper_bone_endpoints,
                                      helper_bone_parents, #offset_ratio=0.0,
                                      startpoints=helper_bone_endpoints-1e-6)
 
-helper_rig = HelperBonesHandler(test_skeleton, helper_indices) 
+helper_rig = HelperBonesHandler(test_skeleton, 
+                                helper_indices,
+                                mass=MASS, 
+                                stiffness=STIFFNESS,
+                                mass_dscale=MASS_DSCALE,
+                                spring_dscale=SPRING_DSCALE) 
 
 # TODO: you could also add insert_point_handle() to Skeleton class
 # that creates a zero-length bone (we need to render bone tips as spheres to see that)
@@ -113,11 +121,11 @@ line_segments = np.reshape(np.arange(0, 2*(n_bones-1)), (n_bones-1, 2))
 skel_mesh = add_skeleton(plotter, rest_bone_locations, line_segments)
 plotter.open_movie(RESULT_PATH + "/igl-skeleton.mp4")
 
-n_repeats = 5
+n_repeats = 10
 n_frames = 2
 for _ in range(n_repeats):
     for frame in range(n_frames):
-        for _ in range(24 * 2):
+        for _ in range(24):
             theta = pose[frame]
             trans = None
             # WARNING (TODO): No relative translation yet!

--- a/tests/fk_test_spring.py
+++ b/tests/fk_test_spring.py
@@ -13,6 +13,7 @@ import pyvista as pv
 
 import __init__
 from skeleton import Skeleton
+from spring_rig_helper import SpringRigContainer
 from pyvista_render_tools import add_skeleton
 from global_vars import IGL_DATA_PATH, RESULT_PATH
 
@@ -77,8 +78,13 @@ pose = np.array([
 
 test_skeleton = create_skeleton(joint_locations, kintree)
 helper_indices  = add_helper_bones(test_skeleton, helper_bone_endpoints, 
-                 helper_bone_parents, #offset_ratio=0.0,
-                 startpoints=helper_bone_endpoints-1e-4)
+                                     helper_bone_parents, #offset_ratio=0.0,
+                                     startpoints=helper_bone_endpoints-1e-6)
+
+helper_bones = np.array(test_skeleton.bones)[helper_indices]
+helper_rig = SpringRigContainer(helper_bones) # TODO: could you do the naming more consistent? i.e. spring_rig_helper SpringRigContainer and helper_rig are all different names!
+
+
 # TODO: you could also add insert_point_handle() to Skeleton class
 # that creates a zero-length bone (we need to render bone tips as spheres to see that)
 

--- a/tests/fk_test_spring.py
+++ b/tests/fk_test_spring.py
@@ -20,6 +20,8 @@ from global_vars import IGL_DATA_PATH, RESULT_PATH
 # ---------------------------------------------------------------------------- 
 # Declare helper functions
 # ---------------------------------------------------------------------------- 
+# TODO: Could we move these functions to skeleton class so that every other test
+# can utilize them?
 def create_skeleton(joint_locations, kintree):
     test_skeleton = Skeleton(root_vec = joint_locations[0])
     for edge in kintree:
@@ -65,7 +67,7 @@ pose = np.array([
                 [
                  [0.,0.,0.],
                  [0.,0.,0.],
-                 [10., 10., 0.],
+                 [90., 10., 0.],
                  [0.,0.,0.],
                  [0.,0.,0.],
                  [0.,0.,0.],
@@ -77,13 +79,11 @@ pose = np.array([
 # ---------------------------------------------------------------------------- 
 
 test_skeleton = create_skeleton(joint_locations, kintree)
-helper_indices  = add_helper_bones(test_skeleton, helper_bone_endpoints, 
+helper_indices = add_helper_bones(test_skeleton, helper_bone_endpoints, 
                                      helper_bone_parents, #offset_ratio=0.0,
                                      startpoints=helper_bone_endpoints-1e-6)
 
-helper_bones = np.array(test_skeleton.bones)[helper_indices]
-helper_rig = HelperBonesHandler(helper_bones) # TODO: could you do the naming more consistent? i.e. spring_rig_helper SpringRigContainer and helper_rig are all different names!
-
+helper_rig = HelperBonesHandler(test_skeleton, helper_indices) 
 
 # TODO: you could also add insert_point_handle() to Skeleton class
 # that creates a zero-length bone (we need to render bone tips as spheres to see that)
@@ -100,7 +100,7 @@ plotter.camera.azimuth = -90
 # Add skeleton mesh based on T-pose locations
 # ---------------------------------------------------------------------------- 
 EXCLUDE_ROOT = True
-n_bones = len(test_skeleton.bones)
+n_bones = len(test_skeleton.rest_bones)
 rest_bone_locations = test_skeleton.get_rest_bone_locations(exclude_root=EXCLUDE_ROOT)
 line_segments = np.reshape(np.arange(0, 2*(n_bones-1)), (n_bones-1, 2))
 # TODO: rename get_rest_bone_locations() to get_rest_bones() that will also return
@@ -110,7 +110,7 @@ line_segments = np.reshape(np.arange(0, 2*(n_bones-1)), (n_bones-1, 2))
 skel_mesh = add_skeleton(plotter, rest_bone_locations, line_segments)
 plotter.open_movie(RESULT_PATH + "/igl-skeleton.mp4")
 
-n_repeats = 10
+n_repeats = 5
 n_frames = 2
 for _ in range(n_repeats):
     for frame in range(n_frames):
@@ -120,9 +120,11 @@ for _ in range(n_repeats):
             posed_bone_locations = test_skeleton.pose_bones(theta, degrees=True, exclude_root=EXCLUDE_ROOT)
             
             # TODO: simulate the mass
+            simulated_locations = helper_rig.update(test_skeleton)
+            print(">>> Simulated locations", simulated_locations)
             
             # TODO: update the posed_bone_locations (maybe not directly update the skeleton bones' locations?)
-            
+            print(">> WARNING: PLEASE DON'T FORGET TO UPDATE THE BONE TIPS... See the line below")
             skel_mesh.points = posed_bone_locations
     
             # Write a frame. This triggers a render.

--- a/tests/fk_test_spring.py
+++ b/tests/fk_test_spring.py
@@ -32,13 +32,17 @@ def add_helper_bones(test_skeleton, helper_bone_endpoints, helper_bone_parents,
     n_helper = len(helper_bone_parents)
     if len(startpoints)==0: startpoints = np.repeat([None],n_helper)
     
+    helper_indices = []
     for i in range(n_helper):
-        test_skeleton.insert_bone(endpoint = helper_bone_endpoints[i],
-                                  parent_idx = helper_bone_parents[i],
-                                  at_the_tip=False,
-                                  offset_ratio = offset_ratio,
-                                  startpoint = startpoints[i]
-                                  )
+        bone_idx = test_skeleton.insert_bone(endpoint = helper_bone_endpoints[i],
+                                              parent_idx = helper_bone_parents[i],
+                                              at_the_tip=False,
+                                              offset_ratio = offset_ratio,
+                                              startpoint = startpoints[i]
+                                              )
+        helper_indices.append(bone_idx)
+    return helper_indices
+
 # ---------------------------------------------------------------------------- 
 # Set skeletal animation data
 # ---------------------------------------------------------------------------- 
@@ -72,9 +76,11 @@ pose = np.array([
 # ---------------------------------------------------------------------------- 
 
 test_skeleton = create_skeleton(joint_locations, kintree)
-add_helper_bones(test_skeleton, helper_bone_endpoints, 
+helper_indices  = add_helper_bones(test_skeleton, helper_bone_endpoints, 
                  helper_bone_parents, #offset_ratio=0.0,
                  startpoints=helper_bone_endpoints-1e-4)
+# TODO: you could also add insert_point_handle() to Skeleton class
+# that creates a zero-length bone (we need to render bone tips as spheres to see that)
 
 # ---------------------------------------------------------------------------- 
 # Create plotter 
@@ -106,6 +112,11 @@ for _ in range(n_repeats):
             theta = pose[frame]
             #t = trans[frame]
             posed_bone_locations = test_skeleton.pose_bones(theta, degrees=True, exclude_root=EXCLUDE_ROOT)
+            
+            # TODO: simulate the mass
+            
+            # TODO: update the posed_bone_locations (maybe not directly update the skeleton bones' locations?)
+            
             skel_mesh.points = posed_bone_locations
     
             # Write a frame. This triggers a render.

--- a/tests/zero_length_spring_test.py
+++ b/tests/zero_length_spring_test.py
@@ -34,7 +34,7 @@ mass_spring_system.fix_mass(0)
 
 # Apply rigid transformation (rotation, translation) to fixed mass
 t = np.array([0.1, 0.1, -0.2])
-mass_spring_system.translate_mass(0, t)
+#mass_spring_system.translate_mass(0, t)
 
 
 # -----------------------------------------------------------------------------
@@ -63,6 +63,11 @@ def callback(step):
     if ((step+1) % 50) == 0:
         print(">> Step ", step+1)
         
+    if (step) % 5 == 0 and step < 400:
+        print(">> Force applied...")
+        mass_spring_system.translate_mass(0, np.random.randn(3) / 100)
+
+        
     mass_spring_system.simulate()
 
     # Step 2 - Get current mass positions and update rendered particles
@@ -80,7 +85,7 @@ def callback(step):
 # Note that "duration" might be misleading, it is not the duration of callback but 
 # rather duration of timer that waits before calling the callback function.
 dt_milliseconds = int(dt * 1000) 
-n_simulation_steps = 400
+n_simulation_steps = 800
 plotter.add_timer_event(max_steps=n_simulation_steps, duration=dt_milliseconds, callback=callback)
 
 plotter.enable_mesh_picking(left_clicking=True)#, pickable_window=False)


### PR DESCRIPTION
``` diff
+ Add a HelperBonesHandler class
+ Test a single spring helper bone
- Rename variables
```

* Add a class, HelperBonesHandler whose main job is to return the simulated joint positions provided the pose rotations at every frame. It is initiated via providing a complete rig and the indices of the helpers in the rig. So we need to decide the helper bones locations and add them on Skeleton class first, before providing the skeleton to HelperBonesHandler.

* Test a single spring helper bone at fk_test_spring.py. The bone jiggles with a certain mass stiffness settings however the system goes unstable very easily. The mass-spring simulation module needs to be stabilized before moving on to other goals.